### PR TITLE
Accept array as value in getFieldCounter

### DIFF
--- a/app/code/community/Ho/Import/Model/Import.php
+++ b/app/code/community/Ho/Import/Model/Import.php
@@ -1237,12 +1237,12 @@ class Ho_Import_Model_Import extends Varien_Object
         }
 
         $configurableSku = $this->_getConfigNode(self::IMPORT_CONFIG_CB_SKU);
-        if (! $configurableSku) {
-            return;
-        }
         $calculatePrice = (bool) $this->_getConfigNode(self::IMPORT_CONFIG_CB_CALCULATE_PRICE);
         $calculatePriceInStock = (bool) $this->_getConfigNode(self::IMPORT_CONFIG_CB_CALCULATE_PRICE_IN_STOCK);
         $sku = $this->_getMapper()->mapItem($configurableSku);
+        if (! $sku) {
+            return $this;
+        }
 
         // Force array if single attribute is given with the 'value' parameter.
         $configurableAttributes = (array) $this->_getMapper()->mapItem(

--- a/app/code/community/Ho/Import/Model/Import.php
+++ b/app/code/community/Ho/Import/Model/Import.php
@@ -1355,7 +1355,7 @@ class Ho_Import_Model_Import extends Varien_Object
                 $configurable['admin'][0]['special_price'] =
                     $configurable['admin'][0][$specialPriceKey] != PHP_INT_MAX && $configurable['admin'][0][$specialPriceKey] > 0
                         ? $configurable['admin'][0][$specialPriceKey]
-                        : null;
+                        : $this->_fastSimpleImport->getSymbolEmptyFields();
 
                 foreach ($configurable['admin'] as &$row) {
                     if (! isset($row['_super_attribute_final_price'])) {


### PR DESCRIPTION
In my case I want to align an array with `media_image` in `media_lable`, using `ho_import/import_product::getFieldCounter`. 

This way it checks if the value is an array, and if so, get the current index of that value.

**Usage**

``` lang-xml
<_media_lable helper="marissen_blokbordurenimport/product::getFieldCounter">
    <count_field use="_media_image"/>
    <value helper="ho_import/import::getFieldSplit">
        <field field="related_image_labels"/>
        <split>,</split>
    </value>
</_media_lable>
```

And the output:

| *_media_image*            | 75S_red.jpg               | 75S_black.jpg  | 75S_white.jpg | 75S_royal.jpg | 75S_grey.jpg |
| *_media_lable*            | rood                      | zwart          | wit           | royal         | grijs        |