### PR TITLE
fix Warning: array_merge()

### DIFF
--- a/app/code/community/Ho/Import/Model/Import.php
+++ b/app/code/community/Ho/Import/Model/Import.php
@@ -828,7 +828,9 @@ class Ho_Import_Model_Import extends Varien_Object
         $this->_runEvent('source_adapter_before', $this->getProfile());
         $this->_getLog()->log($this->_getLog()->__('Getting source adapter %s', $source->getAttribute('model')));
         $importData = $this->getImportData();
-        $arguments = array_merge($arguments, is_null($importData) ? [] : $importData);
+        if (is_array($arguments)) {
+            $arguments = array_merge($arguments, is_null($importData) ? [] : $importData);
+        }
         $this->_sourceAdapter = Mage::getModel($source->getAttribute('model'), $arguments);
 
         if (!$this->_sourceAdapter) {


### PR DESCRIPTION
I've got this warning if I try to run `php hoimport.php -action line -profile profile_name -line 1`:

```
Getting source adapter ho_import/source_adapter_csv
Warning: array_merge(): Argument #1 is not an array in app/code/community/Ho/Import/Model/Import.php on line 831
```

`array_merge` expects first argument to be an array. 
`$arguments` can be string in case if line 825 was executed.