### PR TITLE
Fix empty transport object in source fieldmap after event

### DIFF
--- a/app/code/community/Ho/Import/Model/Import.php
+++ b/app/code/community/Ho/Import/Model/Import.php
@@ -429,16 +429,9 @@ class Ho_Import_Model_Import extends Varien_Object
                     $exportAdapter->writeRow(array_merge($fieldNames, $row));
                 }
             }
+            $this->_configurableGetConfigurables($transport);
+            $this->_runEvent('source_fieldmap_after', $transport);
             $sourceAdapter->next();
-        }
-        $transport = $this->_getTransport();
-        $this->_runEvent('source_fieldmap_after', $transport);
-        $this->_configurableGetConfigurables($transport);
-        if ($transport->getItems()) {
-            foreach ($transport->getItems() as $item) {
-                $rowCount++;
-                $exportAdapter->writeRow(array_merge($fieldNames, $item));
-            }
         }
 
         $this->setRowCount($rowCount);

--- a/app/code/community/Ho/Import/Model/Import.php
+++ b/app/code/community/Ho/Import/Model/Import.php
@@ -429,16 +429,16 @@ class Ho_Import_Model_Import extends Varien_Object
                     $exportAdapter->writeRow(array_merge($fieldNames, $row));
                 }
             }
-            $transport = $this->_getTransport();
-            $this->_configurableGetConfigurables($transport);
-            if ($transport->getItems()) {
-                foreach ($transport->getItems() as $item) {
-                    $rowCount++;
-                    $exportAdapter->writeRow(array_merge($fieldNames, $item));
-                }
-            }
             $this->_runEvent('source_fieldmap_after', $transport);
             $sourceAdapter->next();
+        }
+        $transport = $this->_getTransport();
+        $this->_configurableGetConfigurables($transport);
+        if ($transport->getItems()) {
+            foreach ($transport->getItems() as $item) {
+                $rowCount++;
+                $exportAdapter->writeRow(array_merge($fieldNames, $item));
+            }
         }
 
         $this->setRowCount($rowCount);

--- a/app/code/community/Ho/Import/Model/Import.php
+++ b/app/code/community/Ho/Import/Model/Import.php
@@ -429,7 +429,14 @@ class Ho_Import_Model_Import extends Varien_Object
                     $exportAdapter->writeRow(array_merge($fieldNames, $row));
                 }
             }
+            $transport = $this->_getTransport();
             $this->_configurableGetConfigurables($transport);
+            if ($transport->getItems()) {
+                foreach ($transport->getItems() as $item) {
+                    $rowCount++;
+                    $exportAdapter->writeRow(array_merge($fieldNames, $item));
+                }
+            }
             $this->_runEvent('source_fieldmap_after', $transport);
             $sourceAdapter->next();
         }


### PR DESCRIPTION
This pull request is an attempt to fix issue #133.

The source_fieldmap_after event uses `$transport`. Shouldn't the event be dispatched inside the loop then?
I'm not quite sure about the position of the call of the event  and `_configurableGetConfigurables()` function though.
