### PR TITLE
Fix 'entity codes are mixed' exception on empty import

### DIFF
--- a/app/code/community/Ho/Import/Model/ImportExport/Resource/Import/Data.php
+++ b/app/code/community/Ho/Import/Model/ImportExport/Resource/Import/Data.php
@@ -1,0 +1,42 @@
+<?php
+
+class Ho_Import_Model_ImportExport_Resource_Import_Data extends Mage_ImportExport_Model_Resource_Import_Data
+{
+    /**
+     * Return behavior from import data table.
+     *
+     * @throws Exception
+     * @return string
+     */
+    public function getBehavior()
+    {
+        $adapter = $this->_getReadAdapter();
+        $behaviors = array_unique($adapter->fetchCol(
+            $adapter->select()
+                ->from($this->getMainTable(), array('behavior'))
+        ));
+        if (count($behaviors) != 1) {
+            Mage::throwException(Mage::helper('importexport')->__('Error in data structure: behaviors are mixed'));
+        }
+        return $behaviors[0];
+    }
+
+    /**
+     * Return entity type code from import data table.
+     *
+     * @throws Exception
+     * @return string
+     */
+    public function getEntityTypeCode()
+    {
+        $adapter = $this->_getReadAdapter();
+        $entityCodes = array_unique($adapter->fetchCol(
+            $adapter->select()
+                ->from($this->getMainTable(), array('entity'))
+        ));
+        if (count($entityCodes) != 1) {
+            Mage::throwException(Mage::helper('importexport')->__('Error in data structure: entity codes are mixed'));
+        }
+        return $entityCodes[0];
+    }
+}

--- a/app/code/community/Ho/Import/Model/ImportExport/Resource/Import/Data.php
+++ b/app/code/community/Ho/Import/Model/ImportExport/Resource/Import/Data.php
@@ -15,8 +15,11 @@ class Ho_Import_Model_ImportExport_Resource_Import_Data extends Mage_ImportExpor
             $adapter->select()
                 ->from($this->getMainTable(), array('behavior'))
         ));
-        if (count($behaviors) != 1) {
+        if (count($behaviors) > 1) {
             Mage::throwException(Mage::helper('importexport')->__('Error in data structure: behaviors are mixed'));
+        }
+        elseif (count($behaviors) == 0) {
+            return 'unknown';
         }
         return $behaviors[0];
     }
@@ -34,8 +37,11 @@ class Ho_Import_Model_ImportExport_Resource_Import_Data extends Mage_ImportExpor
             $adapter->select()
                 ->from($this->getMainTable(), array('entity'))
         ));
-        if (count($entityCodes) != 1) {
+        if (count($entityCodes) > 1) {
             Mage::throwException(Mage::helper('importexport')->__('Error in data structure: entity codes are mixed'));
+        }
+        elseif (count($entityCodes) == 0) {
+            return 'unknown';
         }
         return $entityCodes[0];
     }

--- a/app/code/community/Ho/Import/etc/config.xml
+++ b/app/code/community/Ho/Import/etc/config.xml
@@ -40,11 +40,11 @@
 				<class>Ho_Import_Helper</class>
 			</ho_import>
 		</helpers>
-		<models>
-			<ho_import>
-				<class>Ho_Import_Model</class>
+        <models>
+            <ho_import>
+                <class>Ho_Import_Model</class>
                 <resourceModel>ho_import_resource</resourceModel>
-			</ho_import>
+            </ho_import>
             <ho_import_resource>
                 <class>Ho_Import_Model_Resource</class>
                 <entities>
@@ -53,7 +53,12 @@
                     </entity>
                 </entities>
             </ho_import_resource>
-		</models>
+            <importexport_resource>
+                <rewrite>
+                    <import_data>Ho_Import_Model_ImportExport_Resource_Import_Data</import_data>
+                </rewrite>
+            </importexport_resource>
+        </models>
         <resources>
             <ho_import_setup>
                 <setup>


### PR DESCRIPTION
It should be possible for an import source to contain no products to be imported without this necessarily being an error condition. This is important for processing multiple source files as we only want to mark a source file as processed when it has been processed without error.

This PR fixes an assumption in Magento core that there is always something to import (i.e. saveBunch() has been called), and prevents it from throwing an error in this case, so that the import can complete successfully.